### PR TITLE
fix: transition component bug.

### DIFF
--- a/src/layout/components/AppMain.vue
+++ b/src/layout/components/AppMain.vue
@@ -9,17 +9,15 @@ const key = computed(() => {
 </script>
 
 <template>
-  <section class="app-main">
     <router-view v-slot="{ Component }">
       <transition name="fade-transform" mode="out-in">
-        <!-- <keep-alive> -->
-        <div>
-          <component :is="Component" :key="key" />
-        </div>
-        <!-- </keep-alive> -->
+        <section class="app-main">
+          <!-- <keep-alive> -->
+            <component :is="Component" :key="key" />
+          <!-- </keep-alive> -->
+        </section>
       </transition>
     </router-view>
-  </section>
 </template>
 
 <style lang="scss" scoped>

--- a/src/layout/components/AppMain.vue
+++ b/src/layout/components/AppMain.vue
@@ -13,7 +13,9 @@ const key = computed(() => {
     <router-view v-slot="{ Component }">
       <transition name="fade-transform" mode="out-in">
         <!-- <keep-alive> -->
-        <component :is="Component" :key="key" />
+        <div>
+          <component :is="Component" :key="key" />
+        </div>
         <!-- </keep-alive> -->
       </transition>
     </router-view>

--- a/src/layout/components/AppMain.vue
+++ b/src/layout/components/AppMain.vue
@@ -11,9 +11,9 @@ const key = computed(() => {
 <template>
     <router-view v-slot="{ Component }">
       <transition name="fade-transform" mode="out-in">
-        <section class="app-main">
+        <section class="app-main" :key="key">
           <!-- <keep-alive> -->
-            <component :is="Component" :key="key" />
+            <component :is="Component" />
           <!-- </keep-alive> -->
         </section>
       </transition>


### PR DESCRIPTION
**When the component has mutiple root, the \<Transition/\> component can't be animated that target compontent can't be displayed(blank content).**
**I set a root element for the \<component/\> to prevent this from happening.**

![image](https://user-images.githubusercontent.com/64176534/200467385-0e00e898-e3f8-49f5-b872-97b83f269745.png)
![image](https://user-images.githubusercontent.com/64176534/200467401-27f07f54-c0ee-44a8-8129-d91c7f420e1f.png)
