### PR TITLE
增加后台接口返回菜单功能

### DIFF
--- a/src/api/login/index.ts
+++ b/src/api/login/index.ts
@@ -24,3 +24,12 @@ export function getUserInfoApi() {
     method: "get"
   })
 }
+
+
+/** 获取用户菜单 */
+export function getUserMenuApi() {
+  return request<Login.UserMenuResponseData>({
+    url: "users/menu",
+    method: "get"
+  })
+}

--- a/src/api/login/types/login.ts
+++ b/src/api/login/types/login.ts
@@ -12,3 +12,5 @@ export type LoginCodeResponseData = IApiResponseData<string>
 export type LoginResponseData = IApiResponseData<{ token: string }>
 
 export type UserInfoResponseData = IApiResponseData<{ username: string; roles: string[] }>
+
+export type UserMenuResponseData = IApiResponseData<{ menu: any[] }>

--- a/src/config/async-route.ts
+++ b/src/config/async-route.ts
@@ -6,6 +6,12 @@ interface IAsyncRouteSettings {
    * 2. 假如项目不需要根据不同的用户来显示不同的页面，则应该将 open: false
    */
   open: boolean
+
+  /**
+   * 是否后台返回菜单
+   * 1. 开启后需要后端配合开发返回菜单接口，菜单数据格式参考菜单mock数据
+   */
+  apiReturnMenu: boolean
   /** 当动态路由功能关闭时：
    * 1. 应该将所有路由都写到常驻路由里面（表明所有登陆的用户能访问的页面都是一样的）
    * 2. 系统自动给当前登录用户赋值一个默认的角色（默认为 admin，拥有所有页面权限）
@@ -15,6 +21,7 @@ interface IAsyncRouteSettings {
 
 const asyncRouteSettings: IAsyncRouteSettings = {
   open: true,
+  apiReturnMenu: false,
   defaultRoles: ["admin"]
 }
 

--- a/src/store/modules/permission.ts
+++ b/src/store/modules/permission.ts
@@ -36,12 +36,12 @@ export const usePermissionStore = defineStore("permission", () => {
   const routes = ref<RouteRecordRaw[]>([])
   const dynamicRoutes = ref<RouteRecordRaw[]>([])
 
-  const setRoutes = (roles: string[]) => {
+  const setRoutes = (roles: string[],menus: any[]) => {
     let accessedRoutes
-    if (roles.includes("admin")) {
+    if (!roles.includes("admin")) {
       accessedRoutes = asyncRoutes
     } else {
-      accessedRoutes = filterAsyncRoutes(asyncRoutes, roles)
+      accessedRoutes = filterAsyncRoutes(menus, roles)
     }
     routes.value = constantRoutes.concat(accessedRoutes)
     dynamicRoutes.value = accessedRoutes

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -5,7 +5,7 @@ import { usePermissionStore } from "./permission"
 import { useTagsViewStore } from "./tags-view"
 import { getToken, removeToken, setToken } from "@/utils/cache/cookies"
 import router, { resetRouter } from "@/router"
-import { loginApi, getUserInfoApi } from "@/api/login"
+import { loginApi, getUserInfoApi, getUserMenuApi } from "@/api/login";
 import { type ILoginRequestData } from "@/api/login/types/login"
 import { type RouteRecordRaw } from "vue-router"
 
@@ -13,7 +13,7 @@ export const useUserStore = defineStore("user", () => {
   const token = ref<string>(getToken() || "")
   const roles = ref<string[]>([])
   const username = ref<string>("")
-
+  const menus = ref<any[]>([])
   const permissionStore = usePermissionStore()
   const tagsViewStore = useTagsViewStore()
 
@@ -46,6 +46,20 @@ export const useUserStore = defineStore("user", () => {
         .then((res) => {
           roles.value = res.data.roles
           username.value = res.data.username
+          resolve(res)
+        })
+        .catch((error) => {
+          reject(error)
+        })
+    })
+  }
+
+  /** 获取用户菜单 */
+  const getMenu = () => {
+    return new Promise((resolve, reject) => {
+      getUserMenuApi()
+        .then((res) => {
+          menus.value = res.data.menu
           resolve(res)
         })
         .catch((error) => {
@@ -86,7 +100,7 @@ export const useUserStore = defineStore("user", () => {
     tagsViewStore.delAllCachedViews()
   }
 
-  return { token, roles, username, setRoles, login, getInfo, changeRoles, logout, resetToken }
+  return { token, roles, username, setRoles, login, getInfo, changeRoles, logout, resetToken, getMenu, menus }
 })
 
 /** 在 setup 外使用 */

--- a/src/utils/permission.ts
+++ b/src/utils/permission.ts
@@ -1,5 +1,5 @@
 import { useUserStoreHook } from "@/store/modules/user"
-
+const modules = import.meta.glob('@/views/*/*.vue');
 /** 全局权限判断函数，和指令 v-permission 功能类似 */
 export const checkPermission = (value: string[]): boolean => {
   if (value && value instanceof Array && value.length > 0) {
@@ -13,3 +13,20 @@ export const checkPermission = (value: string[]): boolean => {
     return false
   }
 }
+
+// 递归处理菜单 后台返回的组件字符串形式改为变量引入  这里用到了Glob导入
+export const menuHandle = (apiMenu : any[]): any[] =>{
+  apiMenu.forEach(((item :any, index)=>{
+    if(item.component === 'Layout'){
+      item.component = () => import("@/layout/index.vue")
+    }else if(item.component){
+      item.component = modules['/src'+item.component]
+    }
+    if(item.children){
+      menuHandle(item.children)
+    }
+  }))
+  return apiMenu;
+}
+
+


### PR DESCRIPTION
增加后台返回菜单功能，需要下面两步。

1、增加拉取菜单api：
`api/v1/users/menu   //get方法`
返回值如下，menu与项目里的鉴权菜单保持了一致：
```
{
	"code": 0,
	"data": {
		"menu": [{
			"path": "/permission",
			"component": "Layout",
			"redirect": "/permission/page",
			"name": "Permission",
			"meta": {
				"title": "权限管理",
				"svgIcon": "lock",
				"roles": ["admin", "editor"],
				"alwaysShow": true
			},
			"children": [{
				"path": "page",
				"component": "/views/permission/page.vue",
				"name": "PagePermission",
				"meta": {
					"title": "页面权限",
					"roles": ["admin"]
				}
			}, {
				"path": "directive",
				"component": "/views/permission/directive.vue",
				"name": "DirectivePermission",
				"meta": {
					"title": "指令权限"
				}
			}]
		}, {
			"path": "/:pathMatch(.*)*",
			"redirect": "/404",
			"name": "ErrorPage",
			"meta": {
				"hidden": true
			}
		}]
	},
	"message": "success"
}
```

2、更改配置，开启从后台api拉取菜单
```
// 文件 src/config/async-route.ts  第24行  apiReturnMenu参数设置为true
apiReturnMenu: true,

```

重新run项目，就可以从后台拉取菜单了，
