### PR TITLE
refactor: 将TagsView组件中部分方法提取至store，方便其他页面调用

### DIFF
--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,56 @@
+import { useSettingsStore } from "@/store/modules/settings"
+import { ITagView, useTagsViewStore } from "@/store/modules/tags-view"
+import router from "@/router"
+import { computed } from "vue"
+enum TagsActionEnum {
+  REFRESH,
+  CLOSE_ALL,
+  CLOSE_OTHER,
+  CLOSE_CURRENT,
+  CLOSE
+}
+export function useTags() {
+  const settingStore = useSettingsStore()
+
+  function isShowTagsView() {
+    return settingStore.showTagsView
+  }
+
+  const tagsViewStore = useTagsViewStore()
+
+  const route = computed(() => {
+    return router.currentRoute.value
+  })
+
+  async function handleTabAction(action: TagsActionEnum, tag: ITagView = route.value) {
+    if (!isShowTagsView()) {
+      console.log("TagsView未开启")
+      return
+    }
+    switch (action) {
+      case TagsActionEnum.REFRESH:
+        await tagsViewStore.refreshSelectedTag(tag)
+        break
+
+      case TagsActionEnum.CLOSE_ALL:
+        await tagsViewStore.closeAllTags(tag)
+        break
+
+      case TagsActionEnum.CLOSE_OTHER:
+        await tagsViewStore.closeOthersTags(tag)
+        break
+
+      case TagsActionEnum.CLOSE_CURRENT:
+      case TagsActionEnum.CLOSE:
+        await tagsViewStore.closeSelectedTag(tag)
+        break
+    }
+  }
+  return {
+    refresh: (tag: ITagView) => handleTabAction(TagsActionEnum.REFRESH, tag),
+    closeAll: (tag?: ITagView) => handleTabAction(TagsActionEnum.CLOSE_ALL, tag),
+    closeOther: (tag: ITagView) => handleTabAction(TagsActionEnum.CLOSE_OTHER, tag),
+    close: (tag?: ITagView) => handleTabAction(TagsActionEnum.CLOSE, tag),
+    closeCurrent: () => handleTabAction(TagsActionEnum.CLOSE_CURRENT)
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -217,6 +217,14 @@ export const constantRoutes: RouteRecordRaw[] = [
         meta: {
           title: "useFullscreenLoading"
         }
+      },
+      {
+        path: "use-tags",
+        component: () => import("@/views/hook-demo/use-tags.vue"),
+        name: "UseTags",
+        meta: {
+          title: "useTags"
+        }
       }
     ]
   }

--- a/src/store/modules/tags-view.ts
+++ b/src/store/modules/tags-view.ts
@@ -8,7 +8,10 @@ export const useTagsViewStore = defineStore("tags-view", () => {
   const route = router.currentRoute
   const visitedViews = ref<ITagView[]>([])
   const cachedViews = ref<string[]>([])
-
+  const affixTags = ref<ITagView[]>([])
+  const setAffixTags = (tags: ITagView[]) => {
+    affixTags.value = tags
+  }
   const isActive = (tag: ITagView) => {
     return tag.path === route.value.path
   }
@@ -61,13 +64,24 @@ export const useTagsViewStore = defineStore("tags-view", () => {
     closeSelectedTag(route.value)
   }
 
-  const closeAllTags = (view: ITagView, affixTags: ITagView[]) => {
+  const closeAllTags = (view: ITagView) => {
     delAllVisitedViews()
     delAllCachedViews()
-    if (affixTags.some((tag) => tag.path === route.value.path)) {
+    if (affixTags.value.some((tag) => tag.path === route.value.path)) {
       return
     }
     toLastView(visitedViews.value, view)
+  }
+  const refreshSelectedTag = (view: ITagView) => {
+    delCachedView(view)
+    router.replace({ path: "/redirect" + view.path, query: view.query })
+  }
+  const closeOthersTags = (selectedTag: ITagView) => {
+    if (selectedTag.fullPath !== route.value.path && selectedTag.fullPath !== undefined) {
+      router.push(selectedTag.fullPath)
+    }
+    delOthersVisitedViews(selectedTag)
+    delOthersCachedViews(selectedTag)
   }
 
   const toLastView = (visitedViews: ITagView[], view: ITagView) => {
@@ -133,6 +147,10 @@ export const useTagsViewStore = defineStore("tags-view", () => {
     delAllVisitedViews,
     delAllCachedViews,
     isActive,
+    affixTags,
+    setAffixTags,
+    refreshSelectedTag,
+    closeOthersTags,
     closeSelectedTag,
     closeCurrentTag,
     closeAllTags

--- a/src/views/hook-demo/use-tags.vue
+++ b/src/views/hook-demo/use-tags.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { useTags } from "@/hooks/useTags"
+const { closeCurrent, refresh } = useTags()
+</script>
+
+<template>
+  <div class="app-container">
+    <el-card>
+      <el-button @click="closeCurrent">关闭当前Tag</el-button>
+      <el-button @click="refresh($route)">刷新当前Tag</el-button>
+    </el-card>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/views/menu/menu2/index.vue
+++ b/src/views/menu/menu2/index.vue
@@ -1,5 +1,16 @@
+<script setup lang="ts">
+import { useTagsViewStore } from "@/store/modules/tags-view"
+const tagsViewStore = useTagsViewStore()
+
+const handleCloseTag = () => {
+  tagsViewStore.closeCurrentTag()
+}
+</script>
 <template>
   <div class="app-container">
-    <el-card> menu 2 </el-card>
+    <el-card>
+      menu 2
+      <el-button @click="handleCloseTag">关闭当前Tag</el-button>
+    </el-card>
   </div>
 </template>

--- a/src/views/menu/menu2/index.vue
+++ b/src/views/menu/menu2/index.vue
@@ -1,16 +1,5 @@
-<script setup lang="ts">
-import { useTagsViewStore } from "@/store/modules/tags-view"
-const tagsViewStore = useTagsViewStore()
-
-const handleCloseTag = () => {
-  tagsViewStore.closeCurrentTag()
-}
-</script>
 <template>
   <div class="app-container">
-    <el-card>
-      menu 2
-      <el-button @click="handleCloseTag">关闭当前Tag</el-button>
-    </el-card>
+    <el-card> menu 2 </el-card>
   </div>
 </template>


### PR DESCRIPTION
在某些表单页面，我们希望表单提交后可以自动关闭当前标签页，将tagsView组件内的方法提取至store方便其他组件调用。