### PR TITLE
fix: 兼容 TagsView 中出现多个相同的 Tag 路由，且开启 keepAlive 的情况

### DIFF
--- a/src/layouts/components/TagsView/index.vue
+++ b/src/layouts/components/TagsView/index.vue
@@ -83,8 +83,9 @@ const refreshSelectedTag = (view: TagView) => {
 
 /** 关闭当前正在右键操作的标签页 */
 const closeSelectedTag = (view: TagView) => {
-  tagsViewStore.delVisitedView(view)
+  // 由于 delCachedView 内部需要先根据 visitedViews 来做判断, 这里必须把 delCachedView 放在 delVisitedView 的前面
   tagsViewStore.delCachedView(view)
+  tagsViewStore.delVisitedView(view)
   isActive(view) && toLastView(tagsViewStore.visitedViews, view)
 }
 

--- a/src/store/modules/tags-view.ts
+++ b/src/store/modules/tags-view.ts
@@ -44,6 +44,8 @@ export const useTagsViewStore = defineStore("tags-view", () => {
   }
 
   const delCachedView = (view: TagView) => {
+    const { length } = visitedViews.value.filter((v) => v.name === view.name)
+    if (length > 1) return
     if (typeof view.name !== "string") return
     const index = cachedViews.value.indexOf(view.name)
     if (index !== -1) cachedViews.value.splice(index, 1)


### PR DESCRIPTION
问题复现步骤：
1. 添加如下路由
    ```ts
    {
        path: "/test",
        component: Layouts,
        name: "Test",
        meta: {
          title: "测试页面",
          alwaysShow: true
        },
        children: [
          {
            path: "",
            component: () => import("@/views/test/index.vue"),
            name: "Test",
            meta: {
              title: "测试页面"
            }
          },
          {
            path: "detail/:id",
            component: () => import("@/views/test/Detail.vue"),
            name: "Detail",
            meta: {
              title: "详情页面",
              hidden: true,
              keepAlive: true
            }
          }
        ]
      }
    ```
2. 创建测试页面
    创建 `src/views/test/index.vue`
    ```vue
    <template>
      <div>
        <el-button @click="$router.push('test/detail/2333')">跳转至详情2333</el-button>
        <el-button @click="$router.push('test/detail/2444')">跳转至详情2444</el-button>
        <el-button @click="$router.push('test/detail/2555')">跳转至详情2555</el-button>
      </div>
    </template>
    ```
    创建 `src/views/test/Detail.vue`
    ```vue
    <template>
      <div class="app-container">
       详情 A 页面
       <el-input v-model="x"></el-input>
      </div>
    </template>
    
    <script setup lang="ts">
    import { onActivated } from 'vue';
    import { onMounted, ref } from 'vue';
    
    defineOptions({
      name: "Detail"
    })
    
    const x = ref("")
    
    onMounted(() => {
      console.log('onMounted')
    })
    
    onActivated(() => {
      console.log('onActivated')
    })
    </script>
    ```

问题描述：使用上述示例代码会创建多个相同的“详情页面”Tag，关闭任意“详情页面”Tag后，会导致其他的“详情页面”刷新

问题解决：[戳这里 ](https://github.com/un-pany/v3-admin-vite/pull/98/files)

缺点：
1. 会导致关闭其中一个详情页后再重新打开该详情页时，依旧是上一次缓存的数据
2. Tag 右键刷新会失效