### PR TITLE
fix: 侧边栏菜单高亮 bug

### DIFF
--- a/src/layouts/components/Sidebar/index.vue
+++ b/src/layouts/components/Sidebar/index.vue
@@ -141,7 +141,7 @@ const tipLineWidth = computed(() => {
 
 :deep(.el-sub-menu) {
   &.is-active {
-    .el-sub-menu__title {
+    > .el-sub-menu__title {
       color: v-bind(activeTextColor) !important;
     }
   }

--- a/src/styles/theme/core/element-plus.scss
+++ b/src/styles/theme/core/element-plus.scss
@@ -18,7 +18,7 @@
     }
     .el-sub-menu {
       &.is-active {
-        .el-sub-menu__title {
+        > .el-sub-menu__title {
           color: $active-font-color !important;
         }
       }

--- a/src/styles/theme/core/layouts.scss
+++ b/src/styles/theme/core/layouts.scss
@@ -28,7 +28,7 @@
     }
     .el-sub-menu {
       &.is-active {
-        .el-sub-menu__title {
+        > .el-sub-menu__title {
           color: $active-font-color !important;
         }
       }


### PR DESCRIPTION
![image](https://github.com/un-pany/v3-admin-vite/assets/50657815/b61fb18e-ac4c-4823-8541-73ead7d3174f)

**问题**：如图，我选中 menu2，却把 menu1 和 menu1-2 都高亮了，即高亮菜单不准确

**期待结果**：选中 menu2 时应该只高亮「多级路由」这一个菜单

**解决**：使用 `>` 选择器选择父元素(`.el-sub-menu.is-active`)的**直接**子元素(`.el-sub-menu__title`)即可

