### PR TITLE
perf: 优化构建速度

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,8 @@ export default (configEnv: ConfigEnv): UserConfigExport => {
     build: {
       /** 消除打包大小超过 500kb 警告 */
       chunkSizeWarningLimit: 2000,
+      /** 禁用 gzip 压缩大小报告 */
+      reportCompressedSize: false,
       /** 打包后静态资源目录 */
       assetsDir: "static",
       rollupOptions: {
@@ -61,7 +63,12 @@ export default (configEnv: ConfigEnv): UserConfigExport => {
       }
     },
     esbuild: {
-      drop: ["console", "debugger"]
+      /** 在打包代码时移除 console.log */
+      pure: ["console.log"],
+      /** 在打包代码时移除 debugger */
+      drop: ["debugger"],
+      /** 在打包代码时移除所有注释 */
+      legalComments: "none"
     },
     /** Vite 插件 */
     plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,11 +52,12 @@ export default (configEnv: ConfigEnv): UserConfigExport => {
       reportCompressedSize: false,
       /** 打包后静态资源目录 */
       assetsDir: "static",
+      /** 分块策略 */
       rollupOptions: {
         output: {
           manualChunks: {
             vue: ["vue", "vue-router", "pinia"],
-            utils: ["lodash-es", "js-cookie", "screenfull", "path-browserify", "path-to-regexp"],
+            elment: ["element-plus", "@element-plus/icons-vue"],
             vxe: ["vxe-table", "vxe-table-plugin-element", "xe-utils"]
           }
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,22 +48,20 @@ export default (configEnv: ConfigEnv): UserConfigExport => {
     build: {
       /** 消除打包大小超过 500kb 警告 */
       chunkSizeWarningLimit: 2000,
-      /** Vite 2.6.x 以上需要配置 minify: "terser", terserOptions 才能生效 */
-      minify: "terser",
-      /** 在打包代码时移除 console.log、debugger 和 注释 */
-      terserOptions: {
-        compress: {
-          drop_console: false,
-          drop_debugger: true,
-          pure_funcs: ["console.log"]
-        },
-        format: {
-          /** 删除注释 */
-          comments: false
-        }
-      },
       /** 打包后静态资源目录 */
-      assetsDir: "static"
+      assetsDir: "static",
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vue: ["vue", "vue-router", "pinia"],
+            utils: ["lodash-es", "js-cookie", "screenfull", "path-browserify", "path-to-regexp"],
+            vxe: ["vxe-table", "vxe-table-plugin-element", "xe-utils"]
+          }
+        }
+      }
+    },
+    esbuild: {
+      drop: ["console", "debugger"]
     },
     /** Vite 插件 */
     plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,7 @@ export default (configEnv: ConfigEnv): UserConfigExport => {
     },
     build: {
       /** 消除打包大小超过 500kb 警告 */
-      chunkSizeWarningLimit: 2000,
+      chunkSizeWarningLimit: 2048,
       /** 禁用 gzip 压缩大小报告 */
       reportCompressedSize: false,
       /** 打包后静态资源目录 */


### PR DESCRIPTION
主要是增加了打包分块和修改混淆编译为esbuild
对比如下：
之前打包的时间和分块大小
![711149e25823835255e9f1e73bc6512](https://github.com/un-pany/v3-admin-vite/assets/27353058/d88e389d-1e7c-4bb0-9373-b2699765ac5a)
现在的打包时间和分块大小
![image](https://github.com/un-pany/v3-admin-vite/assets/27353058/f6c5ff0f-d729-4c26-ac5d-1cbfe9eb153b)
打包时间上优化了35%，由于采用了分块操作，浏览器并发加载包的速度提升