### PR TITLE
fix: app-scrollbar 高度未占满 app-main

### DIFF
--- a/src/layouts/components/AppMain.vue
+++ b/src/layouts/components/AppMain.vue
@@ -31,10 +31,11 @@ const tagsViewStore = useTagsViewStore()
 .app-main {
   width: 100%;
   background-color: var(--v3-body-bg-color);
+  display: flex;
 }
 
 .app-scrollbar {
-  height: 100%;
+  flex-grow: 1;
   overflow: auto;
   @include scrollbar;
 }


### PR DESCRIPTION
![image](https://github.com/un-pany/v3-admin-vite/assets/50657815/12bb8edd-c8d0-4213-8dd5-69e5a5144d53)
如图，虽然给 app-scroll 设置了 `height: 100%;`，但由于父元素 app-main 的高度并不确定，因此实际上 `height: 100%;` 并未生效