### PR TITLE
fix: 使 router/permission 更易读

### DIFF
--- a/src/router/permission.ts
+++ b/src/router/permission.ts
@@ -23,27 +23,25 @@ router.beforeEach(async (to, _from, next) => {
   const token = getToken()
 
   // 判断该用户是否已经登录
-  if (!token || token === '') {
+  if (!token || token === "") {
     // 如果在免登录的白名单中，则直接进入
     if (isWhiteList(to)) {
       next()
-    }
-    else {
+    } else {
       NProgress.done()
-      next('/login')
+      next("/login")
     }
     return
   }
 
   // 如果已经登录，并准备进入 Login 页面，则重定向到主页
-  if (to.path === '/login') {
+  if (to.path === "/login") {
     NProgress.done()
-    return next({ path: '/' })
+    return next({ path: "/" })
   }
 
   // 如果用户已经获得其权限角色
-  if (userStore.roles.length !== 0)
-    return next()
+  if (userStore.roles.length !== 0) return next()
 
   // 否则要重新获取权限角色
   try {
@@ -54,25 +52,22 @@ router.beforeEach(async (to, _from, next) => {
 
       // 根据角色生成可访问的 Routes（可访问路由 = 常驻路由 + 有访问权限的动态路由）
       permissionStore.setRoutes(roles)
-    }
-    else {
+    } else {
       // 没有开启动态路由功能，则启用默认角色
       userStore.setRoles(routeSettings.defaultRoles)
       permissionStore.setRoutes(routeSettings.defaultRoles)
     }
 
     // 将'有访问权限的动态路由' 添加到 Router 中
-    permissionStore.dynamicRoutes
-      .forEach(route => router.addRoute(route))
+    permissionStore.dynamicRoutes.forEach((route) => router.addRoute(route))
 
     next({ ...to, replace: true })
-  }
-  catch (err: any) {
+  } catch (err: any) {
     // 过程中发生任何错误，都直接重置 Token，并重定向到登录页面
     userStore.resetToken()
-    ElMessage.error(err.message || '路由守卫过程发生错误')
+    ElMessage.error(err.message || "路由守卫过程发生错误")
     NProgress.done()
-    next('/login')
+    next("/login")
   }
 })
 

--- a/src/router/permission.ts
+++ b/src/router/permission.ts
@@ -17,57 +17,62 @@ NProgress.configure({ showSpinner: false })
 router.beforeEach(async (to, _from, next) => {
   fixBlankPage()
   NProgress.start()
+
   const userStore = useUserStoreHook()
   const permissionStore = usePermissionStoreHook()
-  // 判断该用户是否登录
-  if (getToken()) {
-    if (to.path === "/login") {
-      // 如果已经登录，并准备进入 Login 页面，则重定向到主页
-      next({ path: "/" })
-      NProgress.done()
-    } else {
-      // 检查用户是否已获得其权限角色
-      if (userStore.roles.length === 0) {
-        try {
-          if (routeSettings.async) {
-            // 注意：角色必须是一个数组！ 例如: ['admin'] 或 ['developer', 'editor']
-            await userStore.getInfo()
-            const roles = userStore.roles
-            // 根据角色生成可访问的 Routes（可访问路由 = 常驻路由 + 有访问权限的动态路由）
-            permissionStore.setRoutes(roles)
-          } else {
-            // 没有开启动态路由功能，则启用默认角色
-            userStore.setRoles(routeSettings.defaultRoles)
-            permissionStore.setRoutes(routeSettings.defaultRoles)
-          }
-          // 将'有访问权限的动态路由' 添加到 Router 中
-          permissionStore.dynamicRoutes.forEach((route) => {
-            router.addRoute(route)
-          })
-          // 确保添加路由已完成
-          // 设置 replace: true, 因此导航将不会留下历史记录
-          next({ ...to, replace: true })
-        } catch (err: any) {
-          // 过程中发生任何错误，都直接重置 Token，并重定向到登录页面
-          userStore.resetToken()
-          ElMessage.error(err.message || "路由守卫过程发生错误")
-          next("/login")
-          NProgress.done()
-        }
-      } else {
-        next()
-      }
-    }
-  } else {
-    // 如果没有 Token
+  const token = getToken()
+
+  // 判断该用户是否已经登录
+  if (!token || token === '') {
+    // 如果在免登录的白名单中，则直接进入
     if (isWhiteList(to)) {
-      // 如果在免登录的白名单中，则直接进入
       next()
-    } else {
-      // 其他没有访问权限的页面将被重定向到登录页面
-      next("/login")
-      NProgress.done()
     }
+    else {
+      NProgress.done()
+      next('/login')
+    }
+    return
+  }
+
+  // 如果已经登录，并准备进入 Login 页面，则重定向到主页
+  if (to.path === '/login') {
+    NProgress.done()
+    return next({ path: '/' })
+  }
+
+  // 如果用户已经获得其权限角色
+  if (userStore.roles.length !== 0)
+    return next()
+
+  // 否则要重新获取权限角色
+  try {
+    if (routeSettings.async) {
+      // 注意：角色必须是一个数组！ 例如: ['admin'] 或 ['developer', 'editor']
+      await userStore.getInfo()
+      const roles = userStore.roles
+
+      // 根据角色生成可访问的 Routes（可访问路由 = 常驻路由 + 有访问权限的动态路由）
+      permissionStore.setRoutes(roles)
+    }
+    else {
+      // 没有开启动态路由功能，则启用默认角色
+      userStore.setRoles(routeSettings.defaultRoles)
+      permissionStore.setRoutes(routeSettings.defaultRoles)
+    }
+
+    // 将'有访问权限的动态路由' 添加到 Router 中
+    permissionStore.dynamicRoutes
+      .forEach(route => router.addRoute(route))
+
+    next({ ...to, replace: true })
+  }
+  catch (err: any) {
+    // 过程中发生任何错误，都直接重置 Token，并重定向到登录页面
+    userStore.resetToken()
+    ElMessage.error(err.message || '路由守卫过程发生错误')
+    NProgress.done()
+    next('/login')
   }
 })
 

--- a/src/router/permission.ts
+++ b/src/router/permission.ts
@@ -17,17 +17,17 @@ NProgress.configure({ showSpinner: false })
 router.beforeEach(async (to, _from, next) => {
   fixBlankPage()
   NProgress.start()
-
   const userStore = useUserStoreHook()
   const permissionStore = usePermissionStoreHook()
   const token = getToken()
 
   // 判断该用户是否已经登录
-  if (!token || token === "") {
+  if (!token) {
     // 如果在免登录的白名单中，则直接进入
     if (isWhiteList(to)) {
       next()
     } else {
+      // 其他没有访问权限的页面将被重定向到登录页面
       NProgress.done()
       next("/login")
     }
@@ -49,7 +49,6 @@ router.beforeEach(async (to, _from, next) => {
       // 注意：角色必须是一个数组！ 例如: ['admin'] 或 ['developer', 'editor']
       await userStore.getInfo()
       const roles = userStore.roles
-
       // 根据角色生成可访问的 Routes（可访问路由 = 常驻路由 + 有访问权限的动态路由）
       permissionStore.setRoutes(roles)
     } else {
@@ -57,10 +56,10 @@ router.beforeEach(async (to, _from, next) => {
       userStore.setRoles(routeSettings.defaultRoles)
       permissionStore.setRoutes(routeSettings.defaultRoles)
     }
-
     // 将'有访问权限的动态路由' 添加到 Router 中
     permissionStore.dynamicRoutes.forEach((route) => router.addRoute(route))
-
+    // 确保添加路由已完成
+    // 设置 replace: true, 因此导航将不会留下历史记录
     next({ ...to, replace: true })
   } catch (err: any) {
     // 过程中发生任何错误，都直接重置 Token，并重定向到登录页面


### PR DESCRIPTION
在不改变原有逻辑的情况下，减少 `/src/router/permission.ts` 的嵌套层数，尽早 return 来减少分支的判断，使其更易读

[预览地址](https://v3-admin-vite-l3ittyj8j-chilfish.vercel.app/#/login)