### PR TITLE
chore: 移除已经废弃的 vscode-typescript-vue-plugin插件, 已被volar扩展取代

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "vue.vscode-typescript-vue-plugin",
     "vue.volar",
     "antfu.unocss",
     "vitest.explorer",


### PR DESCRIPTION
<img width="773" alt="image" src="https://github.com/un-pany/v3-admin-vite/assets/21010051/d90ecea4-6137-4479-b14a-ea2d4172f747">
