### PR TITLE
style: fix the width of some icons when the sidebar was collapsed

### DIFF
--- a/src/layouts/components/Sidebar/SidebarItem.vue
+++ b/src/layouts/components/Sidebar/SidebarItem.vue
@@ -91,7 +91,7 @@ const resolvePath = (routePath: string) => {
 
 .el-icon {
   width: 1em !important;
-  margin-right: 12px;
+  margin-right: 12px !important;
   font-size: 18px;
 }
 </style>

--- a/src/layouts/components/Sidebar/SidebarItem.vue
+++ b/src/layouts/components/Sidebar/SidebarItem.vue
@@ -90,7 +90,7 @@ const resolvePath = (routePath: string) => {
 }
 
 .el-icon {
-  width: 1em;
+  width: 1em !important;
   margin-right: 12px;
   font-size: 18px;
 }


### PR DESCRIPTION
修复侧边栏收起时，「表格」和「Hook」的 icon 宽度和其他菜单 icon 不一致，导致对齐问题