### PR TITLE
feat: add show version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "unocss": "0.61.3",
     "vite": "5.3.3",
     "vite-plugin-svg-icons": "2.0.1",
+    "vite-plugin-version-mark": "^0.1.0",
     "vite-svg-loader": "5.1.0",
     "vitest": "2.0.3",
     "vue-eslint-parser": "9.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       vite-plugin-svg-icons:
         specifier: 2.0.1
         version: 2.0.1(vite@5.3.3(@types/node@20.14.10)(sass@1.77.8))
+      vite-plugin-version-mark:
+        specifier: ^0.1.0
+        version: 0.1.0(vite@5.3.3(@types/node@20.14.10)(sass@1.77.8))
       vite-svg-loader:
         specifier: 5.1.0
         version: 5.1.0(vue@3.4.31(typescript@5.5.3))
@@ -587,46 +590,55 @@ packages:
     resolution: {integrity: sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.1':
     resolution: {integrity: sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.1':
     resolution: {integrity: sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.1':
     resolution: {integrity: sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
     resolution: {integrity: sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.1':
     resolution: {integrity: sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.1':
     resolution: {integrity: sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.1':
     resolution: {integrity: sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.1':
     resolution: {integrity: sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.1':
     resolution: {integrity: sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==}
@@ -3030,6 +3042,11 @@ packages:
     resolution: {integrity: sha512-6ktD+DhV6Rz3VtedYvBKKVA2eXF+sAQVaKkKLDSqGUfnhqXl3bj5PPkVTl3VexfTuZy66PmINi8Q6eFnVfRUmA==}
     peerDependencies:
       vite: '>=2.0.0'
+
+  vite-plugin-version-mark@0.1.0:
+    resolution: {integrity: sha512-Na9KG6anEwAQVUKm3DOl4AufzvkgWlOogBnGAMR6YEcMMOYMl45/0KqMuvNxGd0WR8aW8cpUiGHDCFlIZ15YeQ==}
+    peerDependencies:
+      vite: '*'
 
   vite-svg-loader@5.1.0:
     resolution: {integrity: sha512-M/wqwtOEjgb956/+m5ZrYT/Iq6Hax0OakWbokj8+9PXOnB7b/4AxESHieEtnNEy7ZpjsjYW1/5nK8fATQMmRxw==}
@@ -6489,6 +6506,10 @@ snapshots:
       vite: 5.3.3(@types/node@20.14.10)(sass@1.77.8)
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-version-mark@0.1.0(vite@5.3.3(@types/node@20.14.10)(sass@1.77.8)):
+    dependencies:
+      vite: 5.3.3(@types/node@20.14.10)(sass@1.77.8)
 
   vite-svg-loader@5.1.0(vue@3.4.31(typescript@5.5.3)):
     dependencies:

--- a/src/views/dashboard/components/Admin.vue
+++ b/src/views/dashboard/components/Admin.vue
@@ -1,14 +1,26 @@
+<script lang="ts" setup>
+import { computed } from "vue"
+
+const curVersion = computed(() => __V3_ADMIN_VITE_VERSION__ ?? "")
+</script>
+
 <template>
-  <div class="app-container center">
+  <div class="app-container">
     <el-empty description="欢迎来到 admin 角色专属首页" />
+    <p v-if="curVersion">
+      <span>当前版本：</span>
+      <span>{{ curVersion }}</span>
+    </p>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.center {
+.app-container {
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  color: var(--el-text-color-secondary);
 }
 </style>

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -9,3 +9,5 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+declare const __V3_ADMIN_VITE_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import vueJsx from "@vitejs/plugin-vue-jsx"
 import { createSvgIconsPlugin } from "vite-plugin-svg-icons"
 import svgLoader from "vite-svg-loader"
 import UnoCSS from "unocss/vite"
+import { vitePluginVersionMark } from "vite-plugin-version-mark"
 
 /** 配置项文档：https://cn.vitejs.dev/config */
 export default ({ mode }: ConfigEnv): UserConfigExport => {
@@ -92,7 +93,16 @@ export default ({ mode }: ConfigEnv): UserConfigExport => {
         symbolId: "icon-[dir]-[name]"
       }),
       /** UnoCSS */
-      UnoCSS()
+      UnoCSS(),
+      /** version mark */
+      vitePluginVersionMark({
+        // command: 'git describe --tags',
+        // ifGitSHA: true,
+        // ifShortSHA: true,
+        ifMeta: true,
+        ifLog: true,
+        ifGlobal: true
+      })
     ],
     /** Vitest 单元测试配置：https://cn.vitest.dev/config */
     test: {


### PR DESCRIPTION
在管理系统中，有一些场景非常需要迅速定位出现问题的代码所在，以便切换至对应版本后进行修改。特别是客户很多，每个客户运行着不同版本的代码，而这些代码又可能从属于同一/不同分支。

这时想基于当前客户版本进行修改，如果没有确切的版本号，就很头疼了。

> 场景
- 确认出现问题的版本（多分支 / 同分支不同commit / 多客户 的场景）。
- 测试是否上线成功。
- ...

> 解决办法
- 可以使用 `package.json` 中的 `version` 作为唯一标识。（多适用于开源项目）
- 业务项目很可能并没有维护 `version`，这时可以使用 `git commit SHA` 作为唯一标识，日后如果项目出现bug，通过 `commitSHA` 也可以快速切换至对应版本进行修改。

------
此 PR 增加处理此场景的插件。