### PR TITLE
解决侧边子菜单不需要在侧边显示时出现的bug

### DIFF
--- a/src/layouts/components/Sidebar/SidebarItem.vue
+++ b/src/layouts/components/Sidebar/SidebarItem.vue
@@ -54,7 +54,7 @@ const resolvePath = (routePath: string) => {
 </script>
 
 <template>
-  <template v-if="!alwaysShowRootMenu && theOnlyOneChild && !theOnlyOneChild.children">
+  <template v-if="!alwaysShowRootMenu && theOnlyOneChild && (!theOnlyOneChild.children || theOnlyOneChild.children.filter((item: any) => !item.meta?.hidden).length === 0)">
     <SidebarItemLink v-if="theOnlyOneChild.meta" :to="resolvePath(theOnlyOneChild.path)">
       <el-menu-item :index="resolvePath(theOnlyOneChild.path)">
         <SvgIcon v-if="theOnlyOneChild.meta.svgIcon" :name="theOnlyOneChild.meta.svgIcon" />


### PR DESCRIPTION
当所有子菜单，都设定不再侧边显示后，侧边栏会有问题