### PR TITLE
fix: 修复登录页的主题切换按钮不能跟随配置

### DIFF
--- a/src/pages/login/index.vue
+++ b/src/pages/login/index.vue
@@ -7,7 +7,7 @@ import { Key, Loading, Lock, Picture, User } from "@element-plus/icons-vue"
 import { getLoginCodeApi, loginApi } from "./apis"
 import Owl from "./components/Owl.vue"
 import { useFocus } from "./composables/useFocus"
-  import {useSettingsStore} from "@/pinia/stores/settings"
+import {useSettingsStore} from "@/pinia/stores/settings"
 const settingsStore = useSettingsStore()
 const { showThemeSwitch } = storeToRefs(settingsStore)
 

--- a/src/pages/login/index.vue
+++ b/src/pages/login/index.vue
@@ -7,6 +7,9 @@ import { Key, Loading, Lock, Picture, User } from "@element-plus/icons-vue"
 import { getLoginCodeApi, loginApi } from "./apis"
 import Owl from "./components/Owl.vue"
 import { useFocus } from "./composables/useFocus"
+  import {useSettingsStore} from "@/pinia/stores/settings"
+const settingsStore = useSettingsStore()
+const { showThemeSwitch } = storeToRefs(settingsStore)
 
 const router = useRouter()
 
@@ -82,7 +85,7 @@ createCode()
 
 <template>
   <div class="login-container">
-    <ThemeSwitch class="theme-switch" />
+    <ThemeSwitch class="theme-switch" v-if="showThemeSwitch" />
     <Owl :close-eyes="isFocus" />
     <div class="login-card">
       <div class="title">

--- a/src/pages/login/index.vue
+++ b/src/pages/login/index.vue
@@ -1,19 +1,19 @@
 <script lang="ts" setup>
 import type { FormInstance, FormRules } from "element-plus"
 import type { LoginRequestData } from "./apis/type"
+import { useSettingsStore } from "@/pinia/stores/settings"
 import { useUserStore } from "@/pinia/stores/user"
 import ThemeSwitch from "@@/components/ThemeSwitch/index.vue"
 import { Key, Loading, Lock, Picture, User } from "@element-plus/icons-vue"
 import { getLoginCodeApi, loginApi } from "./apis"
 import Owl from "./components/Owl.vue"
 import { useFocus } from "./composables/useFocus"
-import {useSettingsStore} from "@/pinia/stores/settings"
-const settingsStore = useSettingsStore()
-const { showThemeSwitch } = storeToRefs(settingsStore)
 
 const router = useRouter()
 
 const userStore = useUserStore()
+
+const settingsStore = useSettingsStore()
 
 const { isFocus, handleBlur, handleFocus } = useFocus()
 
@@ -85,7 +85,7 @@ createCode()
 
 <template>
   <div class="login-container">
-    <ThemeSwitch class="theme-switch" v-if="showThemeSwitch" />
+    <ThemeSwitch v-if="settingsStore.showThemeSwitch" class="theme-switch" />
     <Owl :close-eyes="isFocus" />
     <div class="login-card">
       <div class="title">


### PR DESCRIPTION
登录之后，右上角的主题选择是可以控制展示和隐藏的，但是登录界面的主题选择却不可以控制，此PR 用于修复此问题