### PR TITLE
fix: 修复是否缓存标签栏配置异常

### DIFF
--- a/src/pinia/stores/tags-view.ts
+++ b/src/pinia/stores/tags-view.ts
@@ -30,6 +30,7 @@ export const useTagsViewStore = defineStore("tags-view", () => {
   }
 
   const addCachedView = (view: TagView) => {
+    if (!cacheTagsView) return
     if (typeof view.name !== "string") return
     if (cachedViews.value.includes(view.name)) return
     if (view.meta?.keepAlive) {


### PR DESCRIPTION
当前是否缓存标签栏 cacheTagsView 配置异常，关闭之后也会开启缓存功能