### PR TITLE
fix: 修复ElMessage被VxeModal遮挡问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@ initMobileNotification()
 </script>
 
 <template>
-  <el-config-provider :locale="zhCn">
+  <el-config-provider :locale="zhCn" :z-index="20000">
     <router-view />
   </el-config-provider>
 </template>

--- a/src/plugins/vxe-table.ts
+++ b/src/plugins/vxe-table.ts
@@ -5,7 +5,7 @@ import VXETable from "vxe-table" // https://vxetable.cn/#/start/install
 VXETable.setConfig({
   // 全局尺寸
   size: "medium",
-  // 全局 zIndex 起始值，如果项目的的 z-index 样式值过大时就需要跟随设置更大，避免被遮挡
+  // 全局 zIndex 起始值，默认是 999，如果项目的的 z-index 样式值过大时就需要跟随设置更大，避免被遮挡
   zIndex: 9999,
   // 版本号，对于某些带数据缓存的功能有用到，上升版本号可以用于重置数据
   version: 0,


### PR DESCRIPTION
现象：axios.ts 中的 ElMessage 被 VxeModal 所遮挡
原因：
- Element Plus 弹出组件的层级，zIndex 的默认值为 **2000**
- VxeTable 全局 z-index 默认起始是 999， 而在 `setConfig()` 中配置为了 **9999**

<img width="1636" height="626" alt="PixPin_2025-08-07_09-05-36" src="https://github.com/user-attachments/assets/84f52c0f-072e-410f-a2e7-8fffbbe487b0" />
