### PR TITLE
fix: 修复vxe-table高度样式问题

### DIFF
--- a/src/common/assets/styles/vxe-table.scss
+++ b/src/common/assets/styles/vxe-table.scss
@@ -36,3 +36,12 @@
     }
   }
 }
+
+.vxe-table {
+  // 自定义列配置
+  &-custom {
+    &--body {
+      min-height: 80px;
+    }
+  }
+}

--- a/src/plugins/vxe-table.ts
+++ b/src/plugins/vxe-table.ts
@@ -12,6 +12,7 @@ VXETable.setConfig({
   // 全局 loading 提示内容，如果为 null 则不显示文本
   loadingText: null,
   table: {
+    minHeight: 46,
     showHeader: true,
     showOverflow: "tooltip",
     showHeaderOverflow: "tooltip",


### PR DESCRIPTION
问题：启用 footer 时，高度不够时会被自动拉伸高度
<img width="2775" height="1474" alt="PixPin_2025-09-16_14-19-59" src="https://github.com/user-attachments/assets/86f267b2-077c-47c0-aaaa-c037937fbe53" />
修复：设置 table 的 minHeight（默认是 144）

问题：没有数据行时，自定义列配置高度很小（因为设置了 max-height: 8px;）
<img width="2843" height="932" alt="PixPin_2025-09-16_14-20-51" src="https://github.com/user-attachments/assets/b47b6c7c-70fa-4cc3-9f33-4d449809750b" />
修复：修改样式，设置 min-height
