### PR TITLE
docs: 在 README 中补充 Windows 软链接配置说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ V3 Admin Vite is a well-crafted backend management system template, built with p
 # Clone the project
 git clone https://github.com/un-pany/v3-admin-vite.git
 
+# Windows users: enable Developer Mode first (Settings → System → Advanced → Developer Mode; path varies by Windows version)
+# Use --config so symlinks work immediately after cloning
+git clone --config core.symlinks=true https://github.com/un-pany/v3-admin-vite.git
+
+# Already cloned but symlinks are broken? Run this inside the project directory to fix:
+# (Warning: git restore . overwrites uncommitted changes to tracked files. Stash or commit first.)
+# git config core.symlinks true && git restore .
+
 # Enter the project directory
 cd v3-admin-vite
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,14 @@ V3 Admin Vite 是一个精心制作的后台管理系统模板，基于 Vue3、V
 # 克隆项目
 git clone https://github.com/un-pany/v3-admin-vite.git
 
+# Windows 用户：需提前开启开发者模式（设置 → 系统 → 高级 → 开发人员模式，路径因系统版本而异，请自行搜索）
+# 使用 --config 参数，确保 clone 后软链接直接生效
+git clone --config core.symlinks=true https://github.com/un-pany/v3-admin-vite.git
+
+# 已克隆但软链接未生效？在项目目录内执行以下命令修复：
+# （注意：git restore . 会覆盖工作区中已追踪文件的未提交修改，请提前 stash 或提交）
+# git config core.symlinks true && git restore .
+
 # 进入项目目录
 cd v3-admin-vite
 


### PR DESCRIPTION
## 问题

本项目使用 Git 软链接在多个 AI 编程工具（Cursor / Claude / Trae）之间共享配置文件。
Windows 上 `git clone` 后软链接默认不生效，需要额外配置，但 README 中没有任何说明。

## 变更内容

在中英文 README 的「本地开发」步骤中补充 Windows 用户须知：

- 提示需提前开启开发者模式（注明路径因系统版本而异）
- 提供 `--config core.symlinks=true` 的 clone 命令，确保 clone 后软链接直接生效
- 补充「已克隆但软链接未生效」的修复命令，并说明 `git restore .` 会覆盖未提交修改